### PR TITLE
feat: add repeated fields

### DIFF
--- a/templates/generic.md.tpl
+++ b/templates/generic.md.tpl
@@ -1,15 +1,13 @@
 {{- define "field" }}
 
-- `{{ .Name | camelcase | untitle }}` ({{ if .IsRequired }}required{{ else }}optional{{ end }}{{ if .IsRepeated }}, repeated{{ end }}){{ if .ShortDescription }} - {{ .ShortDescription }}{{ end }}
+- `{{ .Name | camelcase | untitle }}` ({{ if .IsRequired }}required{{ else }}optional{{ end }}{{ if .IsRepeated }}, repeated{{ end }}{{ if .IsEnum }}, enum{{ end }}){{ if .ShortDescription }} - {{ .ShortDescription }}{{ end }}
 {{- if and .Description (not .HideDescription) }}
 {{ nindent 4 .Description -}}
 {{ end -}}
 {{ if and .IsEmbed (eq .Package .ComponentPackage) }}
-{{ nindent 4 "Child properties:" }}
 {{- range .Embed.Fields }}{{ include "field" . | indent 4 }}{{ end -}}
 {{ end -}}
 {{ if .IsEnum }}
-{{ nindent 4 "Supported values:" }}
 {{- range .Enum }}
 {{ nindent 4 "-" }} `{{ . }}`
 {{- end -}}

--- a/types/field.go
+++ b/types/field.go
@@ -65,5 +65,12 @@ func ParseField(componentPackage string, f pgs.Field) *Field {
 		}
 	}
 
+	if typ.IsRepeated() && typ.Element().IsEmbed() {
+		field.IsEmbed = true
+
+		field.Embed = ParseMessage(componentPackage, typ.Element().Embed())
+		field.Package = typ.Element().Embed().Package().ProtoName().String()
+	}
+
 	return field
 }


### PR DESCRIPTION
This adds support for showing the fields of repeated fields and tweaks the output to be more compact.

Part of https://github.com/kumahq/kuma-website/issues/599, https://github.com/kumahq/kuma-website/issues/472

See https://github.com/kumahq/kuma-website/pull/915:

[Example](https://deploy-preview-915--kuma.netlify.app/docs/dev/generated/resources/policy_meshgatewayroute/)